### PR TITLE
Fixing the 'clear' argument to restore initials

### DIFF
--- a/LillyMain.py
+++ b/LillyMain.py
@@ -41,8 +41,8 @@ async def turnips(ctx, arg = 0):
         turnips_list[0] = 0
 
     if arg == "clear":
-        #FIXME: This does not work. Should reset to default values, not clear.
-        turnips_list.clear()
+        # Sets turnips_list to its initial values (given they don't change)
+        turnips_list[0:4] = 0, '', 0, 0
         await ctx.send("Turnip price list cleared.")
     elif arg != 0:
         price = int(arg)

--- a/LillyMain.py
+++ b/LillyMain.py
@@ -3,9 +3,11 @@ import discord
 from discord.ext import commands
 import random
 import RoseSecrets
+import copy
 
 bot = commands.Bot(command_prefix='!')
 turnips_list = [0,'',0,0]
+turnips_initial = copy.deepcopy(turnips_list)
 turnip_id = 0000
 
 
@@ -41,8 +43,8 @@ async def turnips(ctx, arg = 0):
         turnips_list[0] = 0
 
     if arg == "clear":
-        # Sets turnips_list to its initial values (given they don't change)
-        turnips_list[0:4] = 0, '', 0, 0
+        # Sets turnips_list to its initial values
+        turnips_list = copy.deepcopy(turnips_initial)
         await ctx.send("Turnip price list cleared.")
     elif arg != 0:
         price = int(arg)


### PR DESCRIPTION
Fixed the 'clear' argument by deepcopying the turnips_list into turnips_initial at the beginning of the program, and then, if the argument 'clear' is called, deepcopying turnips_initial into turnips_list:
That way the fix is modular and wont need tweaking if, e.g., new values are being added to turnips_lists or initial values being tweaked.
Simply overwrote the values at first, but redid it like so to provide modularity should the default turnips_list ever get changed.